### PR TITLE
Allow passing data directly from before hook to after hook

### DIFF
--- a/Source/Runner.php
+++ b/Source/Runner.php
@@ -15,21 +15,23 @@ function test(string $title, Closure $case, ?Closure $before = null, ?Closure $a
     $statistics['cases']++;
 
     try {
-        $beforeHookOutput = $before ? call_user_func($before) : null;
+        $before_hook_output = $before ? call_user_func($before) : null;
 
         $reflection = new ReflectionFunction($case);
         if ($reflection->getNumberOfParameters() > 1) {
-            $caseOutput = call_user_func($case, ...$beforeHookOutput);
+            $case_output = call_user_func($case, ...$before_hook_output);
         } else {
-            $caseOutput = call_user_func($case, $beforeHookOutput);
+            $case_output = call_user_func($case, $before_hook_output);
         }
+
+        $before_inputs = $case_output ?? $before_hook_output;
 
         if ($after) {
             $reflection = new ReflectionFunction($after);
             if ($reflection->getNumberOfParameters() > 1) {
-                call_user_func($after, ...$caseOutput);
+                call_user_func($after, ...$before_inputs);
             } else {
-                call_user_func($after, $caseOutput);
+                call_user_func($after, $before_inputs);
             }
         }
         $statistics['success']++;

--- a/Tests/AfterHookTest.php
+++ b/Tests/AfterHookTest.php
@@ -59,3 +59,16 @@ test(
         assert_true(false === true, 'You should not be here! After hook should not run for failed tests.');
     }
 );
+
+test(
+    title: 'it should receive data from before hook when nothing passed from the case',
+    case: function () {
+        assert_true(true);
+    },
+    before: function () {
+        return 'This is what you should see in after hook';
+    },
+    after: function ($data_from_before) {
+        assert_true($data_from_before === 'This is what you should see in after hook');
+    }
+);


### PR DESCRIPTION
This PR allows passing data from the before hook to the after hook directly. It passes the data if the case returns void.
